### PR TITLE
upd: add comfort scripts and improve feed paging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@faker-js/faker": "^8.2.0",
         "@hapi/boom": "^10.0.1",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.4.2",
@@ -16,6 +17,7 @@
         "@vercel/analytics": "^1.1.1",
         "axios": "^1.5.1",
         "class-variance-authority": "^0.7.0",
+        "faker": "^6.6.6",
         "lucide-react": "^0.287.0",
         "nanoid": "^5.0.2",
         "next": "^13.5.4",
@@ -905,6 +907,21 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.2.0.tgz",
+      "integrity": "sha512-VacmzZqVxdWdf9y64lDOMZNDMM/FQdtM9IsaOPKOm2suYwEatb8VkdHqOzXcDnZbk7YDE2BmsJmy/2Hmkn563g==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0",
+        "npm": ">=6.14.13"
       }
     },
     "node_modules/@fastify/busboy": {
@@ -4990,6 +5007,11 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/faker": {
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-6.6.6.tgz",
+      "integrity": "sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@faker-js/faker": "^8.2.0",
         "@hapi/boom": "^10.0.1",
         "@next-auth/prisma-adapter": "^1.0.7",
         "@prisma/client": "^5.4.2",
@@ -17,7 +16,6 @@
         "@vercel/analytics": "^1.1.1",
         "axios": "^1.5.1",
         "class-variance-authority": "^0.7.0",
-        "faker": "^6.6.6",
         "lucide-react": "^0.287.0",
         "nanoid": "^5.0.2",
         "next": "^13.5.4",
@@ -34,6 +32,7 @@
         "yup": "^1.3.2"
       },
       "devDependencies": {
+        "@faker-js/faker": "^8.2.0",
         "@types/jest": "^29.5.5",
         "@types/node": "^20",
         "@types/react": "^18",
@@ -913,6 +912,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.2.0.tgz",
       "integrity": "sha512-VacmzZqVxdWdf9y64lDOMZNDMM/FQdtM9IsaOPKOm2suYwEatb8VkdHqOzXcDnZbk7YDE2BmsJmy/2Hmkn563g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5007,11 +5007,6 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
-    },
-    "node_modules/faker": {
-      "version": "6.6.6",
-      "resolved": "https://registry.npmjs.org/faker/-/faker-6.6.6.tgz",
-      "integrity": "sha512-9tCqYEDHI5RYFQigXFwF1hnCwcWCOJl/hmll0lr5D2Ljjb0o4wphb69wikeJDz5qCEzXCoPvG6ss5SDP6IfOdg=="
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "test": "jest",
     "postinstall": "prisma generate",
     "genfakedata": "ts-node --transpile-only ./prisma/fakeData.ts",
-    "reset-prisma": "npx run prisma migrate reset",
-    "md-prisma": "npx run prisma migrate dev"
+    "reset-prisma": "npx prisma migrate reset",
+    "md-prisma": "npx prisma migrate dev"
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "postinstall": "prisma generate"
+    "postinstall": "prisma generate",
+    "genfakedata": "ts-node --transpile-only ./prisma/fakeData.ts",
+    "reset-prisma": "npx run prisma migrate reset",
+    "md-prisma": "npx run prisma migrate dev"
   },
   "dependencies": {
     "@hapi/boom": "^10.0.1",
@@ -34,6 +37,7 @@
     "yup": "^1.3.2"
   },
   "devDependencies": {
+    "@faker-js/faker": "^8.2.0",
     "@types/jest": "^29.5.5",
     "@types/node": "^20",
     "@types/react": "^18",

--- a/prisma/fakeData.ts
+++ b/prisma/fakeData.ts
@@ -1,0 +1,53 @@
+const { faker } = require("@faker-js/faker");
+const { PrismaClient: DbClient } = require("@prisma/client");
+const db = new DbClient();
+
+async function genRandomUsers(numUsers: number) {
+  const users = [];
+  for (let i = 0; i < numUsers; i++) {
+    const firstName = faker.person.firstName();
+    const lastName = faker.person.lastName();
+    const name = firstName + " " + lastName;
+    const username = faker.internet.userName({ firstName, lastName });
+    const email = faker.internet.email({ firstName, lastName });
+    const image = faker.internet.avatar();
+    const user = await db.user.create({
+      data: { name, email, username, image },
+    });
+    users.push(user);
+  }
+
+  return users;
+}
+
+async function generateFakeTasks(numTasks: number) {
+  const users = await genRandomUsers(10);
+  const tasks = [];
+  for (let i = 0; i < numTasks; i++) {
+    const title = faker.lorem.words();
+    const description = faker.lorem.sentences();
+    const dueDate = faker.date.future();
+    const completed = faker.datatype.boolean();
+    const consequence = faker.lorem.sentences();
+    const randNum = Math.floor(10 * Math.random()) % 10;
+    const userId = users?.[randNum].id;
+
+    const task = await db.task.create({
+      data: {
+        title,
+        description,
+        dueDate,
+        completed,
+        consequence,
+        userId,
+      },
+    });
+    tasks.push(task);
+  }
+  return tasks;
+}
+
+// Generate 40 fake tasks
+generateFakeTasks(40)
+  .then((tasks) => console.log(tasks))
+  .catch((e) => console.log(e));

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -11,8 +11,8 @@ const getPublicFeed = async (req: NextRequest) => {
   const searchParams = req.nextUrl.searchParams;
   const page = searchParams.get("page");
   const pageSize = searchParams.get("size");
-  const tasks = await taskService.getPublicFeed(page, pageSize);
-  return res.json(tasks);
+  const result = await taskService.getPublicFeed(page, pageSize);
+  return res.json(result);
 };
 export const GET = apiHandler({ GET: getPublicFeed });
 

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -1,0 +1,49 @@
+import { NotifService } from "@/src/lib/services/notifs";
+import { userService } from "@/src/lib/services/user";
+import { Params } from "@/src/lib/types/server";
+import apiHandler from "@/src/utils/api/api.handler";
+import { NextResponse as res } from "next/server";
+
+/**
+ * Marks a notification as seen.
+ * @param {Request} req - The request object.
+ * @param {Params} params - The route parameters.
+ * @returns {Promise<NextResponse>} - The response object.
+ */
+const updateNotif = async (
+  req: Request,
+  { params }: Params
+): Promise<NextResponse> => {
+  const notifId = params.id;
+  const { id: userId } = await userService.validate();
+  const notifService = new NotifService({ userId });
+  await notifService.update(notifId);
+  return res.json({ msg: "Notification updated successfully" });
+};
+export const PUT = apiHandler({ PUT: updateNotif });
+
+/**
+ * @swagger
+ * /api/notifications/{id}:
+ *   put:
+ *     summary: Marks a notification as seen.
+ *     tags: [Notification]
+ *     parameters:
+ *       - in: path
+ *         name: id
+ *         required: true
+ *         description: The ID of the notification to mark as seen.
+ *         schema:
+ *           type: string
+ *     responses:
+ *       200:
+ *         description: The notification was updated successfully.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 msg:
+ *                   type: string
+ *                   description: A success message.
+ */

--- a/src/app/api/notifications/[id]/route.ts
+++ b/src/app/api/notifications/[id]/route.ts
@@ -8,12 +8,9 @@ import { NextResponse as res } from "next/server";
  * Marks a notification as seen.
  * @param {Request} req - The request object.
  * @param {Params} params - The route parameters.
- * @returns {Promise<NextResponse>} - The response object.
+ * @returns {Promise<res>} - The NEXT response object.
  */
-const updateNotif = async (
-  req: Request,
-  { params }: Params
-): Promise<NextResponse> => {
+const updateNotif = async (req: Request, { params }: Params) => {
   const notifId = params.id;
   const { id: userId } = await userService.validate();
   const notifService = new NotifService({ userId });

--- a/src/lib/services/notifs.ts
+++ b/src/lib/services/notifs.ts
@@ -59,4 +59,15 @@ export class NotifService {
       },
     });
   }
+  async update(notifId: string) {
+    const notif = await prisma.notification.findUnique({
+      where: { id: notifId },
+    });
+    if (!notif) throw Boom.notFound("Notification not found");
+    const newNotif = await prisma.notification.update({
+      where: { id: notifId },
+      data: { seen: true },
+    });
+    if (!newNotif) throw Boom.internal("Something went wrong");
+  }
 }

--- a/src/lib/services/task.ts
+++ b/src/lib/services/task.ts
@@ -94,6 +94,9 @@ class TaskService {
     const parsedPage = Math.max(parseInt(page || "1"), 1);
     const take = parseInt(pageSize || "10");
     const skip = (parsedPage - 1) * take;
+    if (!take || !skip) {
+      throw Boom.badRequest("Pls provide integer query values");
+    }
     const [tasks, count] = await Promise.all([
       prisma.task.findMany({
         skip,

--- a/src/lib/services/task.ts
+++ b/src/lib/services/task.ts
@@ -94,7 +94,7 @@ class TaskService {
     const parsedPage = Math.max(parseInt(page || "1"), 1);
     const take = parseInt(pageSize || "10");
     const skip = (parsedPage - 1) * take;
-    if (!take || !skip) {
+    if (isNaN(take) || isNaN(skip)) {
       throw Boom.badRequest("Pls provide integer query values");
     }
     const [tasks, count] = await Promise.all([

--- a/src/lib/services/task.ts
+++ b/src/lib/services/task.ts
@@ -94,25 +94,30 @@ class TaskService {
     const parsedPage = Math.max(parseInt(page || "1"), 1);
     const take = parseInt(pageSize || "10");
     const skip = (parsedPage - 1) * take;
-    return await prisma.task.findMany({
-      skip,
-      take,
+    const [tasks, count] = await Promise.all([
+      prisma.task.findMany({
+        skip,
+        take,
 
-      orderBy: {
-        updatedAt: "desc",
-      },
-      include: {
-        tags: { select: { name: true } },
-        user: {
-          select: {
-            username: true,
-            image: true,
-            id: true,
-            name: true,
+        orderBy: {
+          updatedAt: "desc",
+        },
+        include: {
+          tags: { select: { name: true } },
+          user: {
+            select: {
+              username: true,
+              image: true,
+              id: true,
+              name: true,
+            },
           },
         },
-      },
-    });
+      }),
+      prisma.task.count(),
+    ]);
+    const totalPages = Math.ceil(count / take);
+    return { tasks, totalPages };
   }
 
   async getTasksByTags(tagNames: string[]) {

--- a/src/utils/api/error.handler.ts
+++ b/src/utils/api/error.handler.ts
@@ -18,16 +18,19 @@ export function errorHandler(
         )
     );
   } else if (err instanceof ValidationError) {
-    return res.json({
-      error: {
-        message: "Action failed",
-        err: err.errors.join(", ").replaceAll('"', "'"),
+    return res.json(
+      {
+        error: {
+          message: "Action failed",
+          err: err.errors.join(", ").replaceAll('"', "'"),
+        },
       },
-    });
+      { status: 400 }
+    );
   } else {
-    return res.json({
-      error: { message: "Something went wrong", err },
-      status: Boom.isBoom(err) ? err.output.statusCode : 500,
-    });
+    return res.json(
+      { error: { message: "Something went wrong" } },
+      { status: Boom.isBoom(err) ? err.output.statusCode : 500 }
+    );
   }
 }


### PR DESCRIPTION
## Highlighted Changes

### 1. Fake data
U can now generate fake data with ease. It will generate 10 fake users and 40 tasks per each run

### 2. Laziness 😁
Convienience scripts added to `package.json`
```
    "genfakedata": "ts-node --transpile-only ./prisma/fakeData.ts",
    "reset-prisma": "npx run prisma migrate reset",
    "md-prisma": "npx run prisma migrate dev"
```
Just do `npm run md-prisma` and it will do what's described there

### 3. Notifications / Nudges
- Fix bug where nudges can be created with no provided sender id
- Update notif endpoint now available: PUT `/api/notifications/id`